### PR TITLE
feat(nippo): PostgreSQL environment setup with Docker Compose (#5)

### DIFF
--- a/nippo/.env.example
+++ b/nippo/.env.example
@@ -1,5 +1,6 @@
-# Database
+# Database (docker-compose up で起動するPostgreSQLに接続)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/nippo_dev?schema=public"
+DATABASE_TEST_URL="postgresql://postgres:postgres@localhost:5433/nippo_test?schema=public"
 
 # Next.js
 NEXT_PUBLIC_API_URL="http://localhost:3000/api/v1"

--- a/nippo/Makefile
+++ b/nippo/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev build start clean test lint format db-migrate db-seed docker-build docker-run deploy
+.PHONY: help install dev build start clean test lint format db-migrate db-seed docker-build docker-run deploy up down up-db up-db-test
 
 # Variables
 PROJECT_ID ?= XXXX
@@ -65,7 +65,22 @@ db-studio: ## Open Prisma Studio
 db-reset: ## Reset database
 	npm run db:reset
 
-docker-build: ## Build Docker image
+up: ## Start all services (DB + App) with Docker Compose
+	docker compose up -d
+
+down: ## Stop all Docker Compose services
+	docker compose down
+
+up-db: ## Start development PostgreSQL only
+	docker compose up -d db
+
+up-db-test: ## Start test PostgreSQL only
+	docker compose up -d db-test
+
+logs-db: ## Show PostgreSQL logs
+	docker compose logs -f db
+
+docker-build: ## Build Docker image for production
 	docker build -t $(SERVICE_NAME):latest .
 
 docker-run: ## Run Docker container

--- a/nippo/docker-compose.yml
+++ b/nippo/docker-compose.yml
@@ -1,0 +1,47 @@
+name: nippo-system
+
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: nippo-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: nippo_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d nippo_dev"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  db-test:
+    image: postgres:15-alpine
+    container_name: nippo-postgres-test
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: nippo_test
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d nippo_test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  postgres_data:
+    driver: local
+  postgres_test_data:
+    driver: local

--- a/nippo/docker-compose.yml
+++ b/nippo/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: nippo_dev
     ports:
-      - "5432:5432"
+      # セキュリティ注意: ホスト全インターフェースへの公開を防ぐため localhost に限定
+      # 本番・ステージング環境では POSTGRES_PASSWORD を環境変数で上書きしてください
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
@@ -30,7 +32,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: nippo_test
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     healthcheck:

--- a/nippo/docker/postgres/init/01_extensions.sql
+++ b/nippo/docker/postgres/init/01_extensions.sql
@@ -1,0 +1,3 @@
+-- PostgreSQL 拡張機能の有効化
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";   -- テキスト検索の高速化


### PR DESCRIPTION
## 概要

Issue #5「PostgreSQL環境のセットアップ（Docker Compose）」の実装です。

## 変更内容

### `docker-compose.yml`
開発・テスト用 PostgreSQL 15 環境を定義

| サービス | コンテナ名 | ポート | DB名 | 用途 |
| ------- | --------- | ---- | ---- | ---- |
| `db` | nippo-postgres | 5432 | nippo_dev | 開発用 |
| `db-test` | nippo-postgres-test | 5433 | nippo_test | テスト用（分離） |

**設定ポイント:**
- `postgres:15-alpine` で軽量イメージを使用
- Named volume で**データを永続化**（`docker compose down` でも消えない）
- `pg_isready` による**ヘルスチェック**（10秒間隔、5回リトライ）
- `docker-entrypoint-initdb.d` で初期化スクリプトを自動実行

### `docker/postgres/init/01_extensions.sql`
コンテナ初回起動時に自動実行される初期化スクリプト
- `uuid-ossp`: UUID生成関数
- `pg_trgm`: 日本語テキスト検索の高速化（LIKE検索のインデックス利用）

### `.env.example`
- `DATABASE_TEST_URL` を追加（テスト用DB接続先）

### `Makefile`
Docker Compose 操作コマンドを追加

```bash
make up          # 全サービス起動
make down        # 全サービス停止
make up-db       # 開発用DB のみ起動
make up-db-test  # テスト用DB のみ起動
make logs-db     # DBログ確認
```

## 受入基準の確認

- [x] `docker-compose up` で PostgreSQL が起動する
- [x] データが永続化される設定になっている（named volume）
- [x] ヘルスチェックが設定されている
- [x] テスト環境と開発環境でDB分離されている
- [x] 初期化スクリプトが自動実行される

## 動作確認手順

```bash
# 開発用DB起動
make up-db

# 接続確認
docker exec -it nippo-postgres psql -U postgres -d nippo_dev -c "\l"

# ヘルスチェック確認
docker inspect nippo-postgres | grep -A5 Health

# 停止
make down
```

## 関連 Issue

Closes #5
Depends on #4 (PR #21)