### PR TITLE
feat(nippo): JWT authentication middleware (#8)

### DIFF
--- a/nippo/package.json
+++ b/nippo/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "jsonwebtoken": "^9.0.2",
     "next": "^14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -41,6 +42,7 @@
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.0",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^20.19.33",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/nippo/src/lib/auth/__tests__/jwt.test.ts
+++ b/nippo/src/lib/auth/__tests__/jwt.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import jwt from 'jsonwebtoken';
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+  JwtPayload,
+} from '../jwt';
+
+describe('JWT Utilities', () => {
+  const testPayload: Omit<JwtPayload, 'iat' | 'exp'> = {
+    userId: 'user-123',
+    email: 'test@example.com',
+    isSupervisor: false,
+  };
+
+  const supervisorPayload: Omit<JwtPayload, 'iat' | 'exp'> = {
+    userId: 'supervisor-456',
+    email: 'supervisor@example.com',
+    isSupervisor: true,
+  };
+
+  describe('signAccessToken', () => {
+    it('有効なアクセストークンを生成する', () => {
+      const token = signAccessToken(testPayload);
+
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3); // JWT形式: header.payload.signature
+    });
+
+    it('上長ユーザーのアクセストークンを生成する', () => {
+      const token = signAccessToken(supervisorPayload);
+
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+  });
+
+  describe('verifyAccessToken', () => {
+    it('有効なアクセストークンを検証してペイロードを返す', () => {
+      const token = signAccessToken(testPayload);
+      const decoded = verifyAccessToken(token);
+
+      expect(decoded.userId).toBe('user-123');
+      expect(decoded.email).toBe('test@example.com');
+      expect(decoded.isSupervisor).toBe(false);
+    });
+
+    it('上長フラグが正しくエンコード・デコードされる', () => {
+      const token = signAccessToken(supervisorPayload);
+      const decoded = verifyAccessToken(token);
+
+      expect(decoded.userId).toBe('supervisor-456');
+      expect(decoded.email).toBe('supervisor@example.com');
+      expect(decoded.isSupervisor).toBe(true);
+    });
+
+    it('デコード済みトークンに iat と exp フィールドが含まれる', () => {
+      const beforeSign = Math.floor(Date.now() / 1000);
+      const token = signAccessToken(testPayload);
+      const afterSign = Math.floor(Date.now() / 1000);
+
+      const decoded = verifyAccessToken(token);
+
+      expect(decoded.iat).toBeGreaterThanOrEqual(beforeSign);
+      expect(decoded.iat).toBeLessThanOrEqual(afterSign + 1);
+      expect(decoded.exp).toBeGreaterThan(decoded.iat!);
+    });
+
+    it('改ざんされたアクセストークンは例外をスローする', () => {
+      const token = signAccessToken(testPayload);
+      const parts = token.split('.');
+      // ペイロード部分を改ざん
+      const tamperedPayload = Buffer.from(
+        JSON.stringify({ userId: 'attacker', email: 'hacker@evil.com', isSupervisor: true })
+      ).toString('base64url');
+      const tamperedToken = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+      expect(() => verifyAccessToken(tamperedToken)).toThrow();
+    });
+
+    it('不正な文字列はアクセストークン検証で例外をスローする', () => {
+      expect(() => verifyAccessToken('invalid-token')).toThrow();
+      expect(() => verifyAccessToken('')).toThrow();
+      expect(() => verifyAccessToken('a.b.c')).toThrow();
+    });
+
+    it('期限切れのアクセストークンは例外をスローする', () => {
+      // 過去に期限切れとなるトークンを直接生成する
+      const secret = process.env.JWT_SECRET || 'default-access-secret-for-dev';
+      const expiredToken = jwt.sign(
+        { userId: 'user-123', email: 'test@example.com', isSupervisor: false },
+        secret,
+        { expiresIn: -1 } // 即時期限切れ
+      );
+
+      expect(() => verifyAccessToken(expiredToken)).toThrow(jwt.TokenExpiredError);
+    });
+
+    it('リフレッシュトークン用の秘密鍵で署名されたトークンはアクセストークン検証で例外をスローする', () => {
+      const refreshToken = signRefreshToken(testPayload);
+
+      expect(() => verifyAccessToken(refreshToken)).toThrow();
+    });
+  });
+
+  describe('signRefreshToken', () => {
+    it('有効なリフレッシュトークンを生成する', () => {
+      const token = signRefreshToken(testPayload);
+
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+  });
+
+  describe('verifyRefreshToken', () => {
+    it('有効なリフレッシュトークンを検証してペイロードを返す', () => {
+      const token = signRefreshToken(testPayload);
+      const decoded = verifyRefreshToken(token);
+
+      expect(decoded.userId).toBe('user-123');
+      expect(decoded.email).toBe('test@example.com');
+      expect(decoded.isSupervisor).toBe(false);
+    });
+
+    it('上長フラグがリフレッシュトークンにも正しくエンコードされる', () => {
+      const token = signRefreshToken(supervisorPayload);
+      const decoded = verifyRefreshToken(token);
+
+      expect(decoded.isSupervisor).toBe(true);
+    });
+
+    it('デコード済みリフレッシュトークンに iat と exp フィールドが含まれる', () => {
+      const beforeSign = Math.floor(Date.now() / 1000);
+      const token = signRefreshToken(testPayload);
+      const afterSign = Math.floor(Date.now() / 1000);
+
+      const decoded = verifyRefreshToken(token);
+
+      expect(decoded.iat).toBeGreaterThanOrEqual(beforeSign);
+      expect(decoded.iat).toBeLessThanOrEqual(afterSign + 1);
+      expect(decoded.exp).toBeGreaterThan(decoded.iat!);
+    });
+
+    it('改ざんされたリフレッシュトークンは例外をスローする', () => {
+      const token = signRefreshToken(testPayload);
+      const parts = token.split('.');
+      const tamperedPayload = Buffer.from(
+        JSON.stringify({ userId: 'attacker', email: 'hacker@evil.com', isSupervisor: true })
+      ).toString('base64url');
+      const tamperedToken = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+      expect(() => verifyRefreshToken(tamperedToken)).toThrow();
+    });
+
+    it('不正な文字列はリフレッシュトークン検証で例外をスローする', () => {
+      expect(() => verifyRefreshToken('invalid-token')).toThrow();
+      expect(() => verifyRefreshToken('')).toThrow();
+    });
+
+    it('期限切れのリフレッシュトークンは例外をスローする', () => {
+      const secret = process.env.JWT_REFRESH_SECRET || 'default-refresh-secret-for-dev';
+      const expiredToken = jwt.sign(
+        { userId: 'user-123', email: 'test@example.com', isSupervisor: false },
+        secret,
+        { expiresIn: -1 }
+      );
+
+      expect(() => verifyRefreshToken(expiredToken)).toThrow(jwt.TokenExpiredError);
+    });
+
+    it('アクセストークン用の秘密鍵で署名されたトークンはリフレッシュトークン検証で例外をスローする', () => {
+      const accessToken = signAccessToken(testPayload);
+
+      expect(() => verifyRefreshToken(accessToken)).toThrow();
+    });
+  });
+
+  describe('アクセストークンとリフレッシュトークンの独立性', () => {
+    it('アクセストークンとリフレッシュトークンは互いに検証できない', () => {
+      const accessToken = signAccessToken(testPayload);
+      const refreshToken = signRefreshToken(testPayload);
+
+      // アクセストークンをリフレッシュトークン検証で使用すると失敗する
+      expect(() => verifyRefreshToken(accessToken)).toThrow();
+      // リフレッシュトークンをアクセストークン検証で使用すると失敗する
+      expect(() => verifyAccessToken(refreshToken)).toThrow();
+    });
+  });
+});

--- a/nippo/src/lib/auth/jwt.ts
+++ b/nippo/src/lib/auth/jwt.ts
@@ -1,0 +1,52 @@
+import jwt from 'jsonwebtoken';
+
+export interface JwtPayload {
+  userId: string;
+  email: string;
+  isSupervisor: boolean;
+  iat?: number;
+  exp?: number;
+}
+
+const ACCESS_TOKEN_SECRET = process.env.JWT_SECRET || 'default-access-secret-for-dev';
+const REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_SECRET || 'default-refresh-secret-for-dev';
+const ACCESS_TOKEN_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
+const REFRESH_TOKEN_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || '7d';
+
+/**
+ * アクセストークンを生成する
+ */
+export const signAccessToken = (payload: Omit<JwtPayload, 'iat' | 'exp'>): string => {
+  return jwt.sign(payload, ACCESS_TOKEN_SECRET, {
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
+};
+
+/**
+ * リフレッシュトークンを生成する
+ */
+export const signRefreshToken = (payload: Omit<JwtPayload, 'iat' | 'exp'>): string => {
+  return jwt.sign(payload, REFRESH_TOKEN_SECRET, {
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
+};
+
+/**
+ * アクセストークンを検証してデコードする
+ * @throws {JsonWebTokenError} トークンが無効な場合
+ * @throws {TokenExpiredError} トークンが期限切れの場合
+ */
+export const verifyAccessToken = (token: string): JwtPayload => {
+  const decoded = jwt.verify(token, ACCESS_TOKEN_SECRET);
+  return decoded as JwtPayload;
+};
+
+/**
+ * リフレッシュトークンを検証してデコードする
+ * @throws {JsonWebTokenError} トークンが無効な場合
+ * @throws {TokenExpiredError} トークンが期限切れの場合
+ */
+export const verifyRefreshToken = (token: string): JwtPayload => {
+  const decoded = jwt.verify(token, REFRESH_TOKEN_SECRET);
+  return decoded as JwtPayload;
+};

--- a/nippo/src/lib/auth/middleware.ts
+++ b/nippo/src/lib/auth/middleware.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { verifyAccessToken, JwtPayload } from './jwt';
+
+/**
+ * AuthorizationヘッダーからBearerトークンを取得・検証してユーザー情報を返す
+ * @returns 認証済みユーザーのJWTペイロード、または null（未認証の場合）
+ */
+export const getAuthUser = (request: Request): JwtPayload | null => {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7);
+  if (!token) {
+    return null;
+  }
+
+  try {
+    return verifyAccessToken(token);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * 認証ミドルウェア。未認証の場合は 401 レスポンスを返す。
+ * @returns 認証済みユーザーのJWTペイロード、または 401 NextResponse
+ */
+export const requireAuth = (
+  request: Request
+): JwtPayload | NextResponse => {
+  const user = getAuthUser(request);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return user;
+};
+
+/**
+ * 上長権限チェックミドルウェア。
+ * 未認証の場合は 401、上長でない場合は 403 レスポンスを返す。
+ * @returns 認証済み上長ユーザーのJWTペイロード、または 401/403 NextResponse
+ */
+export const requireSupervisor = (
+  request: Request
+): JwtPayload | NextResponse => {
+  const result = requireAuth(request);
+
+  if (result instanceof NextResponse) {
+    return result;
+  }
+
+  if (!result.isSupervisor) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Summary

- Implement JWT utility functions (sign/verify for access and refresh tokens)
- Implement Next.js App Router authentication middleware
- Add comprehensive unit tests following CLAUDE.md quality rules

Closes #8

## Implementation Details

### Files Added

| File | Description |
|------|-------------|
| `nippo/src/lib/auth/jwt.ts` | JWT utility functions and type definitions |
| `nippo/src/lib/auth/middleware.ts` | Next.js App Router authentication middleware |
| `nippo/src/lib/auth/__tests__/jwt.test.ts` | Unit tests for JWT utilities |

### `nippo/src/lib/auth/jwt.ts`

- `JwtPayload` type: `userId`, `email`, `isSupervisor`, `iat`, `exp`
- `signAccessToken(payload)`: Signs with `JWT_SECRET`, expires in `JWT_EXPIRES_IN` (default: `1h`)
- `signRefreshToken(payload)`: Signs with `JWT_REFRESH_SECRET`, expires in `JWT_REFRESH_EXPIRES_IN` (default: `7d`)
- `verifyAccessToken(token)`: Verifies and decodes access token, throws on invalid/expired
- `verifyRefreshToken(token)`: Verifies and decodes refresh token, throws on invalid/expired

### `nippo/src/lib/auth/middleware.ts`

- `getAuthUser(request)`: Extracts Bearer token from `Authorization` header, returns `JwtPayload | null`
- `requireAuth(request)`: Returns `JwtPayload` or `NextResponse` with `401 Unauthorized`
- `requireSupervisor(request)`: Returns `JwtPayload` or `NextResponse` with `401`/`403 Forbidden`

### Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `JWT_SECRET` | `default-access-secret-for-dev` | Access token signing secret |
| `JWT_REFRESH_SECRET` | `default-refresh-secret-for-dev` | Refresh token signing secret |
| `JWT_EXPIRES_IN` | `1h` | Access token expiry |
| `JWT_REFRESH_EXPIRES_IN` | `7d` | Refresh token expiry |

### `nippo/package.json`

- Added `jsonwebtoken@^9.0.2` to `dependencies`
- Added `@types/jsonwebtoken@^9.0.7` to `devDependencies`

## Test Cases

Tests in `nippo/src/lib/auth/__tests__/jwt.test.ts`:

### `signAccessToken`
- 有効なアクセストークンを生成する (JWT形式 3パーツ確認)
- 上長ユーザーのアクセストークンを生成する

### `verifyAccessToken`
- 有効なアクセストークンを検証してペイロードを返す (`userId`, `email`, `isSupervisor` の値検証)
- 上長フラグが正しくエンコード・デコードされる
- デコード済みトークンに `iat` と `exp` フィールドが含まれる (タイムスタンプ検証)
- 改ざんされたアクセストークンは例外をスローする
- 不正な文字列はアクセストークン検証で例外をスローする
- 期限切れのアクセストークンは例外をスローする (`TokenExpiredError`)
- リフレッシュトークン用秘密鍵で署名されたトークンはアクセストークン検証で例外をスローする

### `signRefreshToken`
- 有効なリフレッシュトークンを生成する

### `verifyRefreshToken`
- 有効なリフレッシュトークンを検証してペイロードを返す
- 上長フラグがリフレッシュトークンにも正しくエンコードされる
- デコード済みリフレッシュトークンに `iat` と `exp` フィールドが含まれる
- 改ざんされたリフレッシュトークンは例外をスローする
- 不正な文字列はリフレッシュトークン検証で例外をスローする
- 期限切れのリフレッシュトークンは例外をスローする (`TokenExpiredError`)
- アクセストークン用秘密鍵で署名されたトークンはリフレッシュトークン検証で例外をスローする

### アクセストークンとリフレッシュトークンの独立性
- アクセストークンとリフレッシュトークンは互いに検証できない

## Test Plan

- [ ] Run `npm test` in `nippo/` directory to verify all unit tests pass
- [ ] Confirm that invalid tokens return 401 on protected API routes
- [ ] Confirm that valid tokens allow user info retrieval
- [ ] Confirm that non-supervisor users receive 403 on supervisor-only routes
- [ ] Verify environment variables override default secrets in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)